### PR TITLE
Handle image loading error immediately instead of timing out

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -66,6 +66,12 @@ export const getColorsFromURI = (uri: string) => {
         resolve(colors);
       }
     };
+    image.onerror = () => {
+      if (!done) {
+        done = true;
+        reject(new Error("Error loading image"));
+      }
+    };
     setTimeout(() => {
       if (!done) {
         done = true;


### PR DESCRIPTION
I didn't notice much of a difference locally but this speeds up loading by avoiding timeouts when we already know there's an error.