### PR TITLE
add backend endpoint to resize images into 10x10 pixel blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       },
       "devDependencies": {
         "@types/color-hash": "^1.0.2",
+        "@types/formidable": "^2.0.5",
         "@types/node": "^17.0.31",
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.3",
@@ -2327,6 +2328,15 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/formidable": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-2.0.5.tgz",
+      "integrity": "sha512-uvMcdn/KK3maPOaVUAc3HEYbCEhjaGFwww4EsX6IJfWIJ1tzHtDHczuImH3GKdusPnAAmzB07St90uabZeCKPA==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -10175,6 +10185,15 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/formidable": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-2.0.5.tgz",
+      "integrity": "sha512-uvMcdn/KK3maPOaVUAc3HEYbCEhjaGFwww4EsX6IJfWIJ1tzHtDHczuImH3GKdusPnAAmzB07St90uabZeCKPA==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "axios": "^1.2.2",
         "color-hash": "^2.0.2",
         "ethers": "^5.7.0",
+        "formidable": "^2.1.1",
         "js-base64": "^3.7.3",
         "next": "^13.0.0",
         "notistack": "^2.0.8",
@@ -3748,6 +3749,11 @@
         "get-intrinsic": "^1.1.3"
       }
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -4578,6 +4584,15 @@
       "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dijkstrajs": {
@@ -5680,6 +5695,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formidable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -5935,6 +5964,14 @@
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hmac-drbg": {
@@ -11311,6 +11348,11 @@
         "get-intrinsic": "^1.1.3"
       }
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -11935,6 +11977,15 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
       "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
+    },
+    "dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "dijkstrajs": {
       "version": "1.0.2",
@@ -12843,6 +12894,17 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formidable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
+      "requires": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      }
+    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -13027,6 +13089,11 @@
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
       }
+    },
+    "hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g=="
     },
     "hmac-drbg": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "axios": "^1.2.2",
     "color-hash": "^2.0.2",
     "ethers": "^5.7.0",
+    "formidable": "^2.1.1",
     "js-base64": "^3.7.3",
     "next": "^13.0.0",
     "notistack": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/color-hash": "^1.0.2",
+    "@types/formidable": "^2.0.5",
     "@types/node": "^17.0.31",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.3",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -28,6 +28,7 @@ import { RedditNameContext } from "../hooks/useRedditNameContext";
 import useWindowSize from "../hooks/useWindowSize";
 import { PinchContext } from "../hooks/usePinchContext";
 import { BlackListContext } from "../hooks/useBlackListContext";
+import { EthersMulticall } from "@morpho-labs/ethers-multicall";
 
 function App({ Component, pageProps }: AppProps) {
   const [mounted, setMounted] = React.useState(false);

--- a/src/pages/api/pixelate-image.ts
+++ b/src/pages/api/pixelate-image.ts
@@ -17,6 +17,9 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
     const form = new IncomingForm();
     form.parse(req, async function(err, fields, files) {
+      if (err) {
+        return res.status(400).json(err)
+      }
         console.log("fields are %o", fields)
         console.log("files are", files.file)
         

--- a/src/pages/api/pixelate-image.ts
+++ b/src/pages/api/pixelate-image.ts
@@ -1,0 +1,36 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { IncomingForm } from "formidable";
+import sharp from 'sharp'
+import fs, { write } from "fs";
+import path from "path";
+
+export const config = {
+  api: {
+    bodyParser: false
+  }
+};
+// eslint-disable-next-line import/no-anonymous-default-export
+export default async (req: NextApiRequest, res: NextApiResponse) => {
+    if (req.method !== 'POST') {
+        res.status(403).json({error: "method was not POST"})
+    }
+
+    const form = new IncomingForm();
+    form.parse(req, async function(err, fields, files) {
+        console.log("fields are %o", fields)
+        console.log("files are", files.file)
+        console.log("cwd is ", process.cwd())
+        
+        const file = Array.isArray(files.file) ? files.file[0] : files.file
+        const fileData = fs.readFileSync(file.filepath)
+        const writePath = path.join(process.cwd(), file.originalFilename!)
+        fs.writeFileSync(writePath, fileData)
+        console.log("wrote a file")
+        const resizedPath = path.join(process.cwd(), `resized-${file.originalFilename}`)
+        await sharp(writePath).resize(128, 128, { fit: 'contain' } ).toFile(resizedPath)
+        const resizedImageBinary = fs.readFileSync(resizedPath)
+        const resizedImageb64 = resizedImageBinary.toString('base64')
+        return res.status(200).json({'img': `data:${file.mimetype};base64,${resizedImageb64}`})
+    })
+    //console.log("pixelate -- body is %o", req.body)
+}

--- a/src/pages/api/pixelate-image.ts
+++ b/src/pages/api/pixelate-image.ts
@@ -19,14 +19,14 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     form.parse(req, async function(err, fields, files) {
         console.log("fields are %o", fields)
         console.log("files are", files.file)
-        console.log("cwd is ", process.cwd())
         
+        const base = process.env.NODE_ENV === 'production' ? '/tmp' : process.cwd()
         const file = Array.isArray(files.file) ? files.file[0] : files.file
         const fileData = fs.readFileSync(file.filepath)
-        const writePath = path.join(process.cwd(), file.originalFilename!)
+        const writePath = path.join(base, file.originalFilename!)
         fs.writeFileSync(writePath, fileData)
         console.log("wrote a file")
-        const resizedPath = path.join(process.cwd(), `resized-${file.originalFilename}`)
+        const resizedPath = path.join(base, `resized-${file.originalFilename}`)
         await sharp(writePath).resize(128, 128, { fit: 'contain' } ).toFile(resizedPath)
         const resizedImageBinary = fs.readFileSync(resizedPath)
         const resizedImageb64 = resizedImageBinary.toString('base64')

--- a/src/pages/api/pixelate-image.ts
+++ b/src/pages/api/pixelate-image.ts
@@ -9,6 +9,9 @@ export const config = {
     bodyParser: false
   }
 };
+
+const RESIZE_DIMENSIONS = [10, 10] // x px, y px
+
 // eslint-disable-next-line import/no-anonymous-default-export
 export default async (req: NextApiRequest, res: NextApiResponse) => {
     if (req.method !== 'POST') {
@@ -20,20 +23,30 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       if (err) {
         return res.status(400).json(err)
       }
-        console.log("fields are %o", fields)
-        console.log("files are", files.file)
         
-        const base = process.env.NODE_ENV === 'production' ? '/tmp' : process.cwd()
-        const file = Array.isArray(files.file) ? files.file[0] : files.file
-        const fileData = fs.readFileSync(file.filepath)
-        const writePath = path.join(base, file.originalFilename!)
-        fs.writeFileSync(writePath, fileData)
-        console.log("wrote a file")
-        const resizedPath = path.join(base, `resized-${file.originalFilename}`)
-        await sharp(writePath).resize(128, 128, { fit: 'contain' } ).toFile(resizedPath)
-        const resizedImageBinary = fs.readFileSync(resizedPath)
-        const resizedImageb64 = resizedImageBinary.toString('base64')
-        return res.status(200).json({'img': `data:${file.mimetype};base64,${resizedImageb64}`})
+      const base = process.env.NODE_ENV === 'production' ? '/tmp' : process.cwd()
+
+      const file = Array.isArray(files.file) ? files.file[0] : files.file
+
+      const fileData = fs.readFileSync(file.filepath)
+      const writePath = path.join(base, file.originalFilename ?? 'filename')
+      fs.writeFileSync(writePath, fileData)
+
+
+      const resizedPath = path.join(base, `resized-${file.originalFilename}`)
+      
+      await sharp(writePath).resize(
+        RESIZE_DIMENSIONS[0], 
+        RESIZE_DIMENSIONS[1], 
+        { fit: 'contain' } 
+      ).toFile(resizedPath)
+      
+      const resizedImageBinary = fs.readFileSync(resizedPath)
+      const resizedImageb64 = resizedImageBinary.toString('base64')
+      
+      return res.status(200).json({
+        resizedImage: `data:${file.mimetype};base64,${resizedImageb64}`,
+        dimensions: RESIZE_DIMENSIONS,
+      })
     })
-    //console.log("pixelate -- body is %o", req.body)
 }

--- a/src/pages/test-image-upload.tsx
+++ b/src/pages/test-image-upload.tsx
@@ -28,7 +28,7 @@ const ImageUpload : FC = () => {
         });
         const b = await response.json()
         console.log("image upload: response is %o", b)
-        setRespImage(b.img)
+        setRespImage(b.resizedImage)
       };
     return (<>
         <p>asdf</p>

--- a/src/pages/test-image-upload.tsx
+++ b/src/pages/test-image-upload.tsx
@@ -4,6 +4,8 @@ import { FC, useState } from "react"
 const ImageUpload : FC = () => {
     const [image, setImage] = useState<string | Blob | null>(null);
     const [createObjectURL, setCreateObjectURL] = useState<ReturnType<typeof URL.createObjectURL> | null>(null);   
+    const [respImage, setRespImage] = useState<string | undefined>(undefined)
+
 
     console.log("image is %o", image)
     console.log("Createobj is %o", createObjectURL)
@@ -24,6 +26,9 @@ const ImageUpload : FC = () => {
           method: "POST",
           body
         });
+        const b = await response.json()
+        console.log("image upload: response is %o", b)
+        setRespImage(b.img)
       };
     return (<>
         <p>asdf</p>
@@ -31,6 +36,7 @@ const ImageUpload : FC = () => {
         <button type='submit' onClick={uploadToServer}>
             submit
         </button>
+        { respImage && <img src={respImage} alt='asdf' />}
     </>)
 }
 export default ImageUpload

--- a/src/pages/test-image-upload.tsx
+++ b/src/pages/test-image-upload.tsx
@@ -1,0 +1,36 @@
+import { FC, useState } from "react"
+
+
+const ImageUpload : FC = () => {
+    const [image, setImage] = useState<string | Blob | null>(null);
+    const [createObjectURL, setCreateObjectURL] = useState<ReturnType<typeof URL.createObjectURL> | null>(null);   
+
+    console.log("image is %o", image)
+    console.log("Createobj is %o", createObjectURL)
+    
+    const uploadToClient = (event: any) => {
+        if (event.target.files && event.target.files[0]) {
+          const i = event.target.files[0];
+    
+          setImage(i);
+          setCreateObjectURL(URL.createObjectURL(i));
+        }
+      };
+    
+      const uploadToServer = async (event: any) => {
+        const body = new FormData();
+        image && body.append("file", image);
+        const response = await fetch("/api/pixelate-image", {
+          method: "POST",
+          body
+        });
+      };
+    return (<>
+        <p>asdf</p>
+        <input type='file' name='image-attachment' onChange={uploadToClient} />
+        <button type='submit' onClick={uploadToServer}>
+            submit
+        </button>
+    </>)
+}
+export default ImageUpload


### PR DESCRIPTION
This PR adds an endpoint `/api/pixelate-image`, which accepts an uploaded image file, and returns back a base64-encoded version of that image resized to be 10x10 pixels using the `sharp` library.

It also adds a test page, `/test-image-upload` that can be used to select an image and see it in action.

Future changes can
1. Allow for arbitrary sizes instead of 10x10, for example if someone wants to span multiple blocks
2. Make a UI to allow user to submit image
3. Make UI to handle the response, eg by also making base64-encoded JSON to populate the `setURI` call on-chain

